### PR TITLE
Added apply command and no apply option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ When attaching configurations to repositories, you can choose:
 - **all**: Apply to all repositories in the organization
 - **public**: Apply only to public repositories
 - **private_or_internal**: Apply only to private and internal repositories
+- **none**: Create the configuration without applying it to any repositories
 
 ## Demo
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/callmegreg/gh-security-config/internal/api"
+	"github.com/callmegreg/gh-security-config/internal/processors"
+	"github.com/callmegreg/gh-security-config/internal/types"
+	"github.com/callmegreg/gh-security-config/internal/ui"
+	"github.com/callmegreg/gh-security-config/internal/utils"
+)
+
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply existing security configurations to repositories",
+	Long:  "Interactive command to apply an existing security configuration to specific repositories across organizations in an enterprise",
+	RunE:  runApply,
+}
+
+func runApply(cmd *cobra.Command, args []string) error {
+	pterm.DefaultHeader.WithFullWidth().WithBackgroundStyle(pterm.NewStyle(pterm.BgCyan)).WithTextStyle(pterm.NewStyle(pterm.FgWhite)).Println("GitHub Enterprise Security Configuration Application")
+	pterm.Println()
+
+	// Extract common flags
+	commonFlags, err := utils.ExtractCommonFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Validate CSV file early if provided
+	if err := utils.ValidateCSVEarly(commonFlags.OrgListPath); err != nil {
+		return err
+	}
+
+	// Validate concurrency
+	if err := utils.ValidateConcurrency(commonFlags.Concurrency); err != nil {
+		return err
+	}
+
+	// Get enterprise name
+	enterprise, err := ui.GetEnterpriseInput()
+	if err != nil {
+		return err
+	}
+
+	// Get GitHub Enterprise Server URL if needed
+	serverURL, err := ui.GetServerURLInput()
+	if err != nil {
+		return err
+	}
+
+	// Set hostname if using GitHub Enterprise Server
+	ui.SetupGitHubHost(serverURL)
+
+	// Fetch organizations (from CSV or enterprise API)
+	orgs, err := api.GetOrganizations(enterprise, commonFlags.OrgListPath)
+	if err != nil {
+		return err
+	}
+
+	if len(orgs) == 0 {
+		ui.ShowNoOrganizationsWarning(commonFlags.OrgListPath)
+		return nil
+	}
+
+	// Get security configuration name to apply
+	configName, err := ui.GetConfigNameForApplication()
+	if err != nil {
+		return err
+	}
+
+	// Verify configuration exists in at least one organization and get its details
+	var configDetails *types.SecurityConfigurationDetails
+	var sourceOrg string
+	for _, org := range orgs {
+		// Check membership for this specific organization
+		status, err := api.CheckSingleOrganizationMembership(org)
+		if err != nil || !status.IsMember || !status.IsOwner {
+			continue
+		}
+
+		configs, err := api.FetchSecurityConfigurations(org)
+		if err != nil {
+			continue
+		}
+
+		configID, found := api.FindConfigurationByName(configs, configName)
+		if found {
+			// Get detailed configuration
+			details, err := api.GetSecurityConfigurationDetails(org, configID)
+			if err == nil {
+				configDetails = details
+				sourceOrg = org
+				break
+			}
+		}
+	}
+
+	if configDetails == nil {
+		pterm.Warning.Printf("Configuration '%s' not found in any accessible organizations.\n", configName)
+		return fmt.Errorf("configuration '%s' not found", configName)
+	}
+
+	// Show configuration details
+	pterm.Info.Printf("Found configuration '%s' in organization '%s'\n", configName, sourceOrg)
+	ui.DisplayCurrentSettings(configDetails.Settings, configDetails.Description)
+	pterm.Println()
+
+	// Get repository attachment scope (without 'none' option)
+	scope, err := ui.GetAttachmentScopeForApplication()
+	if err != nil {
+		return err
+	}
+
+	// Get default setting
+	setAsDefault, err := ui.GetDefaultSetting()
+	if err != nil {
+		return err
+	}
+
+	// Confirm before proceeding
+	confirmed, err := ui.ConfirmApplyOperation(orgs, configName, configDetails.Description, configDetails.Settings, scope, setAsDefault)
+	if err != nil {
+		return err
+	}
+
+	if !confirmed {
+		ui.ShowOperationCancelled()
+		return nil
+	}
+
+	// Process each organization
+	ui.ShowProcessingStart(len(orgs), commonFlags.Concurrency)
+
+	// Create processor for apply command
+	processor := &processors.ApplyProcessor{
+		ConfigName:        configName,
+		ConfigDescription: configDetails.Description,
+		Settings:          configDetails.Settings,
+		Scope:             scope,
+		SetAsDefault:      setAsDefault,
+	}
+
+	// Use concurrent processor
+	concurrentProcessor := processors.NewConcurrentProcessor(orgs, processor, commonFlags.Concurrency)
+	successCount, skippedCount, errorCount := concurrentProcessor.Process()
+
+	utils.PrintCompletionHeader("Security Configuration Application", successCount, skippedCount, errorCount)
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(modifyCmd)
+	rootCmd.AddCommand(applyCmd)
 }
 
 // Execute runs the root command

--- a/internal/processors/apply.go
+++ b/internal/processors/apply.go
@@ -1,0 +1,65 @@
+package processors
+
+import (
+	"fmt"
+
+	"github.com/pterm/pterm"
+
+	"github.com/callmegreg/gh-security-config/internal/api"
+	"github.com/callmegreg/gh-security-config/internal/types"
+)
+
+// ApplyProcessor implements OrganizationProcessor for the apply command
+type ApplyProcessor struct {
+	ConfigName        string
+	ConfigDescription string
+	Settings          map[string]interface{}
+	Scope             string
+	SetAsDefault      bool
+}
+
+// ProcessOrganization processes a single organization for the apply command
+func (ap *ApplyProcessor) ProcessOrganization(org string) types.ProcessingResult {
+	// Check membership using the shared validation function
+	if skipResult := api.ValidateMembershipAndSkip(org); skipResult != nil {
+		return *skipResult
+	}
+
+	result := ap.processOrganization(org)
+	return result
+}
+
+// processOrganization handles the core organization processing logic
+func (ap *ApplyProcessor) processOrganization(org string) types.ProcessingResult {
+	// Check if a configuration with the same name already exists
+	configs, err := api.FetchSecurityConfigurations(org)
+	if err != nil {
+		return types.ProcessingResult{Organization: org, Error: fmt.Errorf("failed to fetch existing security configurations: %w", err)}
+	}
+
+	// Check if configuration already exists
+	existingConfigID, exists := api.FindConfigurationByName(configs, ap.ConfigName)
+
+	if !exists {
+		// Configuration doesn't exist, skip this organization
+		pterm.Info.Printf("Configuration '%s' not found in organization '%s', skipping\n", ap.ConfigName, org)
+		return types.ProcessingResult{Organization: org, Skipped: true}
+	}
+
+	if ap.Scope != "" {
+		err = api.AttachConfigurationToRepos(org, existingConfigID, ap.Scope)
+		if err != nil {
+			return types.ProcessingResult{Organization: org, Error: fmt.Errorf("failed to attach configuration to repositories: %w", err)}
+		}
+	}
+
+	// Set as default if requested
+	if ap.SetAsDefault {
+		err = api.SetConfigurationAsDefault(org, existingConfigID)
+		if err != nil {
+			return types.ProcessingResult{Organization: org, Error: fmt.Errorf("failed to set configuration as default: %w", err)}
+		}
+	}
+
+	return types.ProcessingResult{Organization: org, Success: true}
+}

--- a/internal/processors/generate.go
+++ b/internal/processors/generate.go
@@ -66,10 +66,12 @@ func (gp *GenerateProcessor) processOrganization(org string) error {
 		return fmt.Errorf("failed to create security configuration: %w", err)
 	}
 
-	// Attach configuration to repositories
-	err = api.AttachConfigurationToRepos(org, configID, gp.Scope)
-	if err != nil {
-		return fmt.Errorf("failed to attach configuration to repositories: %w", err)
+	// Attach configuration to repositories only if scope is not "none"
+	if gp.Scope != "none" {
+		err = api.AttachConfigurationToRepos(org, configID, gp.Scope)
+		if err != nil {
+			return fmt.Errorf("failed to attach configuration to repositories: %w", err)
+		}
 	}
 
 	// Set as default if requested

--- a/internal/ui/configuration.go
+++ b/internal/ui/configuration.go
@@ -82,6 +82,7 @@ func GetAttachmentScope() (string, error) {
 		"all",
 		"public",
 		"private_or_internal",
+		"none",
 	}).WithDefaultOption("all").Show("Select repositories to attach configuration to")
 	if err != nil {
 		return "", err
@@ -180,4 +181,32 @@ func GetSecuritySettingsForUpdate(currentSettings map[string]interface{}) (map[s
 	}
 
 	return newSettings, nil
+}
+
+// GetConfigNameForApplication prompts for configuration name to apply
+func GetConfigNameForApplication() (string, error) {
+	configName, err := pterm.DefaultInteractiveTextInput.WithDefaultText("").WithMultiLine(false).Show("Enter the name of the security configuration to apply")
+	if err != nil {
+		return "", err
+	}
+
+	if strings.TrimSpace(configName) == "" {
+		return "", fmt.Errorf("configuration name is required")
+	}
+
+	return strings.TrimSpace(configName), nil
+}
+
+// GetAttachmentScopeForApplication prompts for repository attachment scope (without 'none' option)
+func GetAttachmentScopeForApplication() (string, error) {
+	scope, err := pterm.DefaultInteractiveSelect.WithOptions([]string{
+		"all",
+		"public",
+		"private_or_internal",
+	}).WithDefaultOption("all").Show("Select repositories to attach configuration to")
+	if err != nil {
+		return "", err
+	}
+
+	return scope, nil
 }

--- a/internal/ui/confirmation.go
+++ b/internal/ui/confirmation.go
@@ -183,3 +183,45 @@ func HandleCopyFromOrg(copyFromOrg string) (string, string, map[string]interface
 
 	return selectedConfigData.Name, configDetails.Description, configDetails.Settings, scope, setAsDefault, nil
 }
+
+// ConfirmApplyOperation shows operation summary and asks for confirmation for apply command
+func ConfirmApplyOperation(orgs []string, configName, configDescription string, settings map[string]interface{}, scope string, setAsDefault bool) (bool, error) {
+	pterm.Println()
+	pterm.DefaultHeader.WithFullWidth().WithBackgroundStyle(pterm.NewStyle(pterm.BgYellow)).WithTextStyle(pterm.NewStyle(pterm.FgBlack)).Println("Apply Operation Summary")
+
+	pterm.Printf("Organizations: %d\n", len(orgs))
+	pterm.Printf("Configuration Name: %s\n", pterm.Yellow(configName))
+	pterm.Printf("Configuration Description: %s\n", pterm.Yellow(configDescription))
+	pterm.Println()
+
+	pterm.Info.Println("Security Settings:")
+	for key, value := range settings {
+		valueStr := fmt.Sprintf("%v", value)
+		var coloredValue string
+
+		switch valueStr {
+		case "enabled", "enforced":
+			coloredValue = pterm.Green(valueStr)
+		case "disabled", "unenforced":
+			coloredValue = pterm.Red(valueStr)
+		case "not_set":
+			coloredValue = pterm.Yellow(valueStr)
+		default:
+			coloredValue = pterm.Yellow(valueStr)
+		}
+
+		pterm.Printf("  %s: %s\n", pterm.Cyan(key), coloredValue)
+	}
+	pterm.Println()
+
+	pterm.Printf("Attachment Scope: %s\n", pterm.Magenta(scope))
+	pterm.Printf("Set as Default: %s\n", pterm.Cyan(fmt.Sprintf("%t", setAsDefault)))
+	pterm.Println()
+
+	confirmed, err := pterm.DefaultInteractiveConfirm.WithDefaultText("Proceed with applying security configuration to repositories?").Show()
+	if err != nil {
+		return false, err
+	}
+
+	return confirmed, nil
+}


### PR DESCRIPTION
This pull request introduces a new `apply` command to the CLI tool, allowing users to apply existing security configurations to repositories across organizations. It adds interactive prompts and processing logic for this operation, improves flexibility around repository attachment scopes, and refines the user experience for configuration management.